### PR TITLE
Updated dependencies and test assertions

### DIFF
--- a/lib/address.js
+++ b/lib/address.js
@@ -48,7 +48,7 @@ function _resultAddressComponent(body, componentName) {
   var components = body.address_components || {};
 
   return _.find(components, function(component) {
-    return _.contains(component.types, componentName);
+    return _.includes(component.types, componentName);
   }) || {};
 }
 

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   },
   "homepage": "https://github.com/venables/node-where#readme",
   "dependencies": {
-    "lodash": "^3.10.0",
-    "request": "^2.60.0",
-    "validator": "^3.41.2"
+    "lodash": "^4.17.4",
+    "request": "^2.81.0",
+    "validator": "^7.0.0"
   },
   "devDependencies": {
-    "chai": "^3.2.0",
-    "mocha": "^2.2.5"
+    "chai": "^3.5.0",
+    "mocha": "^3.4.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -37,8 +37,8 @@ describe('where.is', function() {
       expect(result.get('postalCode')).to.equal('94043');
       expect(result.get('country')).to.equal('United States');
       expect(result.get('countryCode')).to.equal('US');
-      expect(result.get('lat')).to.equal(37.419);
-      expect(result.get('lng')).to.equal(-122.058);
+      expect(result.get('lat')).to.equal(37.4192);
+      expect(result.get('lng')).to.equal(-122.0574);
       done();
     });
   });


### PR DESCRIPTION
Part of support request I raised earlier #1

- Updated dependencies
- Lodash changes in lib/address.js  ( _.contains to [_.includes](https://github.com/venables/node-where/pull/2/commits/e65c47563c74bb03ba6d66eb19f4ddfe48e6aa12#diff-d4553b70ba86c98e1755aff961c94db1) ) 
- Test assertion updated - freegeoip.net services' results are [changed.](http://freegeoip.net/json/173.194.33.104)

Test Results:
```
TJ-MB033:node-where techjini$ sudo npm test

> node-where@1.0.0 test /private/var/www/node-where
> mocha test/test.js



  where.is
    ✓ returns an empty Result if given no address
    ✓ geolocates an IPv4 address (824ms)
    ✓ geolocates a postal address (605ms)
    ✓ geolocates a landmark (660ms)


  4 passing (2s)
```